### PR TITLE
Remove /commit/ paths as they break some pages.

### DIFF
--- a/interceptor.js
+++ b/interceptor.js
@@ -16,7 +16,6 @@ function redirect(requestDetails) {
 browser.webRequest.onBeforeRequest.addListener(
     redirect,
     { urls : [
-        "*://github.com/*/commit/*",
         "*://github.com/*/*/pull/*/files"
     ]
     },


### PR DESCRIPTION
Some pages break under `/commit/`, better to remove them.

<img width="934" alt="Screen Shot 2021-10-28 at 11 32 47 AM" src="https://user-images.githubusercontent.com/772937/139315022-81ff7a86-2d2b-4bd6-975d-fa30ee95bea7.png">

Format that breaks is:

https://github.com/USER/REPO/commit/HASH?w=1