### PR TITLE
Handle new `/changes` path GitHub uses for pull requests

### DIFF
--- a/interceptor.js
+++ b/interceptor.js
@@ -16,7 +16,8 @@ function redirect(requestDetails) {
 browser.webRequest.onBeforeRequest.addListener(
     redirect,
     { urls : [
-        "*://github.com/*/*/pull/*/files"
+        "*://github.com/*/*/pull/*/files",
+        "*://github.com/*/*/pull/*/changes"
     ]
     },
     ["blocking"]

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "*://github.com/*/*/pull/*/files"
+    "*://github.com/*/*/pull/*/files",
+    "*://github.com/*/*/pull/*/changes"
   ],
   "applications": {
     "gecko": {


### PR DESCRIPTION
PRs now use `/changes` instead of `/files` - for example, `https://github.com/maksimovic/github-whitespace-disabler/pull/5/changes` - so handle the new path. 

Because GitHub uses Single Page Application routing, this might not be sufficient without a page reload when on the Files Changed tab. Took a stab at handling the SPA routing / XHR request in https://github.com/maksimovic/github-whitespace-disabler/pull/6. 