### PR TITLE
Handle new /changes path GitHub uses for pull requests (including SPA routing)

### DIFF
--- a/content.js
+++ b/content.js
@@ -1,0 +1,19 @@
+function ensureWhitespaceParam() {
+    var url = new URL(window.location.href);
+    var path = url.pathname;
+
+    if ((path.endsWith('/files') || path.endsWith('/changes')) && !url.searchParams.has('w')) {
+        url.searchParams.set('w', 1);
+        window.location.replace(url.href);
+    }
+}
+
+ensureWhitespaceParam();
+
+var lastUrl = window.location.href;
+new MutationObserver(function() {
+    if (window.location.href !== lastUrl) {
+        lastUrl = window.location.href;
+        ensureWhitespaceParam();
+    }
+}).observe(document, { subtree: true, childList: true });

--- a/interceptor.js
+++ b/interceptor.js
@@ -16,7 +16,8 @@ function redirect(requestDetails) {
 browser.webRequest.onBeforeRequest.addListener(
     redirect,
     { urls : [
-        "*://github.com/*/*/pull/*/files"
+        "*://github.com/*/*/pull/*/files",
+        "*://github.com/*/*/pull/*/changes"
     ]
     },
     ["blocking"]

--- a/manifest.json
+++ b/manifest.json
@@ -10,6 +10,13 @@
   "background": {
     "scripts": ["interceptor.js"]
   },
+  "content_scripts": [
+    {
+      "matches": ["*://github.com/*/*/pull/*"],
+      "js": ["content.js"],
+      "run_at": "document_idle"
+    }
+  ],
   "permissions": [
     "webRequest",
     "webRequestBlocking",

--- a/manifest.json
+++ b/manifest.json
@@ -13,7 +13,8 @@
   "permissions": [
     "webRequest",
     "webRequestBlocking",
-    "*://github.com/*/*/pull/*/files"
+    "*://github.com/*/*/pull/*/files",
+    "*://github.com/*/*/pull/*/changes"
   ],
   "applications": {
     "gecko": {


### PR DESCRIPTION
PRs now use `/changes` instead of `/files` - for example, `https://github.com/maksimovic/github-whitespace-disabler/pull/5/changes` - so handle the new path. 

Also add a MutationObserver that should use this new parameter with GitHub's SPA routing. 